### PR TITLE
Generate random values with getrandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,8 +506,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -604,6 +606,7 @@ dependencies = [
  "aead",
  "chacha20poly1305",
  "futures-util",
+ "getrandom",
  "gloo-file",
  "hkdf",
  "js-sys",

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 aead = { version = "0.4.3", features = ["stream"] }
 chacha20poly1305 = "0.9.0"
 futures-util = "0.3.17"
+getrandom = { version = "0.2.3", features = ["js"] }
 gloo-file = "0.1.0"
 hkdf = "0.11.0"
 js-sys = "0.3.55"

--- a/webapp/src/main.rs
+++ b/webapp/src/main.rs
@@ -114,26 +114,9 @@ impl Component for Model {
                     return false;
                 };
 
-                // prepare crypto instance
-                let window = {
-                    if let Some(window) = web_sys::window() {
-                        window
-                    } else {
-                        log::error!("cannot retrieve Window instance");
-                        return false;
-                    }
-                };
-                let crypto = match window.crypto() {
-                    Ok(crypto) => crypto,
-                    Err(err) => {
-                        log::error!("cannot retrieve Crypto instance: {:?}", err);
-                        return false;
-                    }
-                };
-
                 // generate salt for hkdf expand()
                 let mut salt = [0u8; 32];
-                let rand_res = crypto.get_random_values_with_u8_array(&mut salt);
+                let rand_res = getrandom::getrandom(&mut salt);
                 if let Err(err) = rand_res {
                     log::error!("cannot get random salt value: {:?}", err);
                     return false;
@@ -151,7 +134,7 @@ impl Component for Model {
 
                 // generate nonce for XChaCha20Poly1305
                 let mut nonce = [0u8; 19];
-                let rand_res = crypto.get_random_values_with_u8_array(&mut nonce);
+                let rand_res = getrandom::getrandom(&mut nonce);
                 if let Err(err) = rand_res {
                     log::error!("cannot get random nonce value: {:?}", err);
                     return false;


### PR DESCRIPTION
Use [getrandom](https://crates.io/crates/getrandom) crate to generate random nonce instead of using WebCrypto directly.